### PR TITLE
fix(harvester_protocol): remove timelord_reward_puzzle_hash for harvester

### DIFF
--- a/skynet/farmer/farmer_api.py
+++ b/skynet/farmer/farmer_api.py
@@ -435,7 +435,7 @@ class FarmerAPI:
             new_signage_point.sub_slot_iters,
             new_signage_point.signage_point_index,
             new_signage_point.challenge_chain_sp,
-            new_signage_point.timelord_reward_puzzle_hash,
+#            new_signage_point.timelord_reward_puzzle_hash,
             pool_difficulties,
         )
 

--- a/skynet/protocols/harvester_protocol.py
+++ b/skynet/protocols/harvester_protocol.py
@@ -37,7 +37,7 @@ class NewSignagePointHarvester(Streamable):
     sub_slot_iters: uint64
     signage_point_index: uint8
     sp_hash: bytes32
-    timelord_reward_puzzle_hash: bytes32
+#    timelord_reward_puzzle_hash: bytes32
     pool_difficulties: List[PoolDifficulty]
 
 


### PR DESCRIPTION
For class NewSignagePointHarvester,
when Farmer send this type message to harvester
The attribute: timelord_reward_puzzle_hash: bytes32 is meaningless
timelord_reward_puzzle_hash: bytes32 is totally redundancy.

remove it from two files